### PR TITLE
Upgrade version of TensorFlow; Add explicitly to console.logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ COPY src/ ./app
 COPY docker/run.sh .
 COPY nbdime/original.ipynb template.ipynb
 
+RUN pip install tf-nightly-2.0-preview
+
 ENV NBDIME_URL "http://localhost:81/d/"
 
 CMD ["sh", "run.sh"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Twisted==16.6.0
 requests==2.20.1
-flask
+Flask==1.0.2
 tf-nightly-2.0-preview

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Twisted==16.6.0
 requests==2.20.1
 Flask==1.0.2
-tf-nightly-2.0-preview
+tf-nightly-2.0-preview>=2.0.0-dev20190427

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from hashlib import md5
 from typing import Tuple, List
 
 import requests
+import tensorflow as tf
 
 from flask import (
     Flask, redirect, request, render_template, send_from_directory)
@@ -147,13 +148,15 @@ def inject_nbdime(content: str, folder_hash: str) -> str:
                            report_lines=report_lines,
                            after=content[position:],
                            folder=folder_hash,
-                           file='converted.ipynb')
+                           file='converted.ipynb',
+                           tf_version=tf.version.VERSION)
 
 
 @app.route("/")
 def hello():
     """Index page with intro info."""
-    return render_template('index.html')
+    return render_template('index.html',
+                           tf_version=tf.version.VERSION)
 
 
 @app.route('/download/<path:folder>/<path:filename>')

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -82,5 +82,9 @@ Thanks to all amazing people, that in one or another way helped this project:
     <li><a href="https://twitter.com/jerrykur" target="_blank">Jerry Kurata</a> for testing the early versions of the upgrader</li>
 
 </ul>
+
+<script lang="JavaScript">
+    console.log("TensorFlow version is {{tf_version}}")
+</script>
 {% endblock %}
 

--- a/src/templates/nbdime_inject.html
+++ b/src/templates/nbdime_inject.html
@@ -121,4 +121,8 @@ TODO: figure out how to do this properly without hardcoding-->
   background-image: repeating-linear-gradient(45deg, transparent, transparent 5px, rgba(255,255,255,.5) 5px, rgba(255,255,255,.5) 10px);
 }
 </style>
+
+<script lang="JavaScript">
+    console.log("TensorFlow version is {{tf_version}}")
+</script>
 {% include 'data.html' %}

--- a/tf-ipynb/values.yaml
+++ b/tf-ipynb/values.yaml
@@ -12,7 +12,7 @@ containers:
     replicaCount: 1
     port: 80
     healthcheck: /
-    tag: v49
+    tag: v50
 
   - name: nbdime
     repository: gcr.io/brainscode-140622/tf-ipynb.nbdime

--- a/tf-ipynb/values.yaml
+++ b/tf-ipynb/values.yaml
@@ -12,7 +12,7 @@ containers:
     replicaCount: 1
     port: 80
     healthcheck: /
-    tag: v50
+    tag: v51
 
   - name: nbdime
     repository: gcr.io/brainscode-140622/tf-ipynb.nbdime


### PR DESCRIPTION
- Upgrade to the nightly version of TensorFlow. Closes #29 
- Add TensorFlow version logging to browser console
- Add support for line split in single-line "magic"
- Update TensorFlow build to use [fix for multi-line "magic"](https://github.com/tensorflow/tensorflow/commit/93557712d0082a7e9fda3daacefddefb15e5d722#diff-db01673eb6e019b39689cd41bfae3d5e)
- Fix a bug in multi-line magic [tensorflow/PR](https://github.com/tensorflow/tensorflow/pull/28160)
